### PR TITLE
fix issue with minified bootstrap line 'abbr[title]'

### DIFF
--- a/lib/parse/index.js
+++ b/lib/parse/index.js
@@ -224,7 +224,7 @@ module.exports = function(css, options){
     if (!match(/^:\s*/)) return error("property missing ':'");
 
     // val
-    var val = match(/^((?:'(?:\\'|.)*?'|"(?:\\"|.)*?"|\([^\)]*?\)|[^};])+)/);
+    var val = match(/^((?:'(?:\\'|\.)*?'|"(?:\\"|\.)*?"|\([^\)]*?\)|[^};])+)/);
 
     var ret = pos({
       type: 'declaration',


### PR DESCRIPTION
fix issue with minified bootstrap line `'abbr[title]:after{content:" (" attr(title) ")"'`

to understand the issue test against:
`
url("data:image/svg+xml;charset=utf8,%3Csvg viewBox=\\\'0 0 30 30\\\' xmlns=\\\'http://www.w3.org/2000/svg\\\'%3E%3Cpath stroke=\\\'rgba(0, 0, 0, 0.5)\\\' stroke-width=\\\'2\\\' stroke-linecap=\\\'round\\\' stroke-miterlimit=\\\'10\\\' d=\\\'M4 7h22M4 15h22M4 23h22\\\'/%3E%3C/svg%3E")}.navbar-light .navbar-text{color:rgba(0,0,0,.5)}.navbar-light .navbar-text a,.navbar-light .navbar-text a:focus,.navbar-light .navbar-text a:hover{color:rgba(0,0,0,.9)}.navbar-dark .navbar-brand,.navbar-dark .navbar-brand:focus,.navbar-dark .navbar-brand:hover{color:#fff}.navbar-dark .navbar-nav .nav-link{color:hsla(0,0%,100%,.5)}abbr[title]:after{content:" (" attr(title) ")"`